### PR TITLE
chore: fix devcontainer explainshell

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,21 +3,20 @@
   "customizations": {
     "vscode": {
       "extensions": [
-		"mads-hartmann.bash-ide-vscode",
-		"ms-python.python",
-		"ms-python.vscode-pylance",
-		"DavidAnson.vscode-markdownlint"	
-  ]
+        "mads-hartmann.bash-ide-vscode",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "DavidAnson.vscode-markdownlint"
+      ]
     }
   },
   "features": {
-    "ghcr.io/devcontainers/features/python:1.1.0": {},
-    "ghcr.io/devcontainers/features/node:1.3.0": {},
-    "ghcr.io/devcontainers/features/github-cli:1.0.10": {},	    
-    "ghcr.io/devcontainers/features/docker-in-docker:2.5.0": {},
-    "ghcr.io/devcontainers/features/common-utils:2.1.2": {},
+    "ghcr.io/devcontainers/features/python:1.6.4": {},
+    "ghcr.io/devcontainers/features/node:1.6.0": {},
+    "ghcr.io/devcontainers/features/github-cli:1.0.13": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2.11.0": {},
+    "ghcr.io/devcontainers/features/common-utils:2.5.1": {},
     "ghcr.io/lukewiwa/features/shellcheck:0.2.3": {}
-
   },
   "postCreateCommand": "/bin/bash -ex ./.devcontainer/setup.sh > postCreateCommand.log"
 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -4,5 +4,14 @@ npm install -g @devcontainers/cli
 
 pipx install shfmt-py
 
+# Check if the explainshell container is running
+if [ "$(docker ps -q -f name=explainshell)" ]; then
+    # Stop the running container
+    docker stop explainshell
+    # Remove the container
+    docker rm explainshell
+fi
+
+# Run a new explainshell container
 # this will add hover annotations in shell script files, assuming mads-hartmann.bash-ide-vscod is installed
 docker container run --name explainshell --restart always -p 5000:5000 -d spaceinvaderone/explainshell


### PR DESCRIPTION
- Fixed error from `postCreateCommand`, which appeared after restarting devcontainer and was caused by `explainshell` container (which was still running/existing)
- Bumped versions of features
- Fixed formatting in `devcontainer.json`