### PR TITLE
fix(azure-apiops): update regex for assets

### DIFF
--- a/src/azure-apiops/install.sh
+++ b/src/azure-apiops/install.sh
@@ -1,31 +1,24 @@
-
 set -e
 
 . ./library_scripts.sh
 
 # nanolayer is a cli utility which keeps container layers as small as possible
 # source code: https://github.com/devcontainers-contrib/nanolayer
-# `ensure_nanolayer` is a bash function that will find any existing nanolayer installations, 
-# and if missing - will download a temporary copy that automatically get deleted at the end 
+# `ensure_nanolayer` is a bash function that will find any existing nanolayer installations,
+# and if missing - will download a temporary copy that automatically get deleted at the end
 # of the script
 ensure_nanolayer nanolayer_location "v0.5.4"
 
+$nanolayer_location \
+    install \
+    devcontainer-feature \
+    "ghcr.io/devcontainers-contrib/features/gh-release:1.0.23" \
+    --option repo='Azure/apiops' --option binaryNames='extractor' --option assetRegex='^extractor-linux-x64.zip' --option version="$VERSION"
 
 $nanolayer_location \
     install \
     devcontainer-feature \
     "ghcr.io/devcontainers-contrib/features/gh-release:1.0.23" \
-    --option repo='Azure/apiops' --option binaryNames='extractor' --option assetRegex='^extractor.linux-x64.exe' --option version="$VERSION"
-    
-
-
-$nanolayer_location \
-    install \
-    devcontainer-feature \
-    "ghcr.io/devcontainers-contrib/features/gh-release:1.0.23" \
-    --option repo='Azure/apiops' --option binaryNames='publisher' --option assetRegex='^publisher.linux-x64.exe' --option version="$VERSION"
-    
-
+    --option repo='Azure/apiops' --option binaryNames='publisher' --option assetRegex='^publisher-linux-x64.zip' --option version="$VERSION"
 
 echo 'Done!'
-


### PR DESCRIPTION
- Changed regex that's used for the assets extraction (the asset extension has changed from `.exe` [[v4.10.1](https://github.com/Azure/apiops/releases/tag/v4.10.1)] to `.zip` [[v6.0.1.1](https://github.com/Azure/apiops/releases/tag/v6.0.1.1)])
