### PR TITLE
fix(ci): assign permissions permissions for publish step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,10 @@ jobs:
     needs: [run-tests]
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      packages: write
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Added permissions for feature deployment job, so it should be allowed to push the images and releases