### PR TITLE
fix: ansible version mismatch

### DIFF
--- a/src/ansible/install.sh
+++ b/src/ansible/install.sh
@@ -12,7 +12,7 @@ ensure_nanolayer nanolayer_location "v0.5.0"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/pipx-package:1.1.8" \
+    "ghcr.io/devcontainers-extra/features/pipx-package:1.1.9" \
     --option package='ansible-core' --option injections='ansible' --option version="$VERSION"
 
 echo 'Done!'

--- a/src/pipx-package/devcontainer-feature.json
+++ b/src/pipx-package/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Pipx package",
     "id": "pipx-package",
-    "version": "1.1.8",
+    "version": "1.1.9",
     "description": "Installs a pipx package.",
     "documentationURL": "http://github.com/devcontainers-contrib/features/tree/main/src/pipx-package",
     "installsAfter": [

--- a/src/pipx-package/install.sh
+++ b/src/pipx-package/install.sh
@@ -7,7 +7,7 @@ INJECTIONS=${INJECTIONS:-""}
 INCLUDEDEPS=${INCLUDEDEPS:-"false"}
 INTERPRETER=${INTERPRETER:-""}
 
-#  PEP 668  compatibility 
+#  PEP 668  compatibility
 export PIP_BREAK_SYSTEM_PACKAGES=1
 
 # Clean up
@@ -25,7 +25,7 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 updaterc() {
-	if cat /etc/os-release | grep "ID_LIKE=.*alpine.*\|ID=.*alpine.*" ; then
+	if cat /etc/os-release | grep "ID_LIKE=.*alpine.*\|ID=.*alpine.*"; then
 		echo "Updating /etc/profile"
 		echo -e "$1" >>/etc/profile
 	fi
@@ -55,7 +55,7 @@ install_via_pipx() {
 	else
 		local _interpreter="python3"
 	fi
-	
+
 	if [ -z "$INTERPRETER" ]; then # if interpreter selected manually - it should exists (validated above)
 
 		if [ "$_interpreter" = "python3" ]; then
@@ -112,12 +112,11 @@ install_via_pipx() {
 		updaterc "if [[ \"\${PATH}\" != *\"\${PIPX_BIN_DIR}\"* ]]; then export PATH=\"\${PATH}:\${PIPX_BIN_DIR}\"; fi"
 	}
 
-	
-	if  $_interpreter -m pip list | grep pipx >/dev/null 2>&1; then
+	if $_interpreter -m pip list | grep pipx >/dev/null 2>&1; then
 		# if pipx exists in the selected interpreter - use it
 		pipx_bin="$_interpreter -m pipx"
 	elif [ -n "$INTERPRETER" ]; then
-		# if interpreter was *explicitely* selected, 
+		# if interpreter was *explicitely* selected,
 		# and pipx is not installed with it - install it
 		_install_pipx
 		pipx_bin="$_interpreter -m pipx"
@@ -129,7 +128,6 @@ install_via_pipx() {
 		_install_pipx
 		pipx_bin=$PYTHONUSERBASE/bin/pipx
 	fi
-
 
 	if [ "$(${pipx_bin} list --short | grep "$PACKAGE")" != "" ]; then
 		echo "$PACKAGE  already exists - skipping installation"
@@ -148,8 +146,13 @@ install_via_pipx() {
 		injections_array=($INJECTIONS)
 		injections_array_length="${#injections_array[@]}"
 
+		# Save the main package info (with version) to a temporary requirements file
+		# Used in inject command to prevent altering the main package version
+		tmp_requirements_file="/tmp/requirements.txt"
+		echo "$pipx_installation" >$tmp_requirements_file
+
 		for ((i = 0; i < ${injections_array_length}; i++)); do
-			${pipx_bin} inject --pip-args '--no-cache-dir --force-reinstall' -f "$PACKAGE" "${injections_array[$i]}"
+			${pipx_bin} inject --pip-args "--no-cache-dir --force-reinstall -r ${tmp_requirements_file}" -f "$PACKAGE" "${injections_array[$i]}"
 		done
 
 		# cleaning pipx to save disk space

--- a/test/ansible/test_version_selection.sh
+++ b/test/ansible/test_version_selection.sh
@@ -4,6 +4,6 @@ set -e
 
 source dev-container-features-test-lib
 
-check "ansible --version | grep 'core 2.13.0'" ansible --version | grep 'core 2.13.0'
+check "ansible version is equal to 2.13.0" bash -c "ansible --version | grep 'core 2.13.0'"
 
 reportResults

--- a/test/pipx-package/install_ansible_specific_version.sh
+++ b/test/pipx-package/install_ansible_specific_version.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+ansible --version
+check "ansible-core version is equal to 2.16.11" bash -c 'ansible --version | grep "core 2.16.11"'
+check "ansible version is equal to 9.10.x" bash -c 'pipx list --include-injected | grep "ansible 9.10."'
+
+reportResults

--- a/test/pipx-package/scenarios.json
+++ b/test/pipx-package/scenarios.json
@@ -31,12 +31,24 @@
     "install_black_custom_interpreter": {
         "image": "debian:bullseye",
         "features": {
-            "ghcr.io/devcontainers/features/python:1": {"version": "3.8.10"},
+            "ghcr.io/devcontainers/features/python:1": {
+                "version": "3.8.10"
+            },
             "pipx-package": {
                 "interpreter": "/usr/local/python/3.8.10/bin/python3",
                 "version": "latest",
                 "package": "black",
                 "injections": "tqdm pylint"
+            }
+        }
+    },
+    "install_ansible_specific_version": {
+        "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+        "features": {
+            "pipx-package": {
+                "version": "2.16.11",
+                "package": "ansible-core",
+                "injections": "ansible"
             }
         }
     }


### PR DESCRIPTION
- Fixed `ansible` test which wasn't catching error with different version being installed
- Fixed `pipx-package` installation script 

The pipx injection command was able to alter the desired version of the main package.
The example situation was described in #43. The desired version of `ansible-core` was bumped during injection of `ansible` package (pipx installed `ansible` in the latest version, which required the newer version of `ansible-core`, so it was bumped as the result)