### PR TITLE
Note that this is not officially related to the Devcontainers project

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 
 This repository is a continuation of the [devcontainers-contrib/features](https://github.com/devcontainers-contrib/features) project, initially developed by [danielbraun89](https://github.com/danielbraun89). The fork was created to maintain and enhance the project due to inactivity in the original repository.
 
+> [!NOTE]
+> This project is not officially associated with or endoresed by the official [Devcontainers](https://containers.dev/) project
+
 ## Usage
 
 Just add a `.devcontainer/devcontainer.json` file with a `features` key. It's

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 This repository is a continuation of the [devcontainers-contrib/features](https://github.com/devcontainers-contrib/features) project, initially developed by [danielbraun89](https://github.com/danielbraun89). The fork was created to maintain and enhance the project due to inactivity in the original repository.
 
 > [!NOTE]
-> This project is not officially associated with or endoresed by the official [Devcontainers](https://containers.dev/) project
+> This project is not officially associated with or endorsed by the official [Devcontainers](https://containers.dev/) project
 
 ## Usage
 


### PR DESCRIPTION
One of the issues with the previous devcontainers-contrib project was that the plethora and name of the project implied an official relationship with the main devcontianers project. I think a different name would be a good idea, but at least there should be an note in the README