### PR TITLE
fix(haskell): install Haskell libraries

### DIFF
--- a/src/haskell/devcontainer-feature.json
+++ b/src/haskell/devcontainer-feature.json
@@ -40,7 +40,7 @@
             "type": "string",
             "proposals": [
                 "",
-                "hspec hspec-contrib"
+                "hspec hspec-contrib QuickCheck HUnit"
             ],
             "default": "",
             "description": "Libraries to install via `cabal install --lib`, such as `hspec` for testing. Separate with spaces. This will add significant initial build time."

--- a/src/haskell/devcontainer-feature.json
+++ b/src/haskell/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Haskell (via ghcup)",
     "id": "haskell",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "description": "Installs Haskell. An advanced, purely functional programming language",
     "documentationURL": "https://github.com/devcontainers-contrib/features/tree/main/src/haskell",
     "options": {
@@ -31,10 +31,19 @@
             "proposals": [
                 "",
                 "hlint",
-                "hlint hspec pandoc"
+                "hlint pandoc-cli"
             ],
             "default": "",
             "description": "Packages to install via `cabal install`, such as `hlint` for linting. Separate with spaces. This will add significant initial build time."
+        },
+        "globalLibraries": {
+            "type": "string",
+            "proposals": [
+                "",
+                "hspec hspec-contrib"
+            ],
+            "default": "",
+            "description": "Libraries to install via `cabal install --lib`, such as `hspec` for testing. Separate with spaces. This will add significant initial build time."
         },
         "installHLS": {
             "type": "boolean",

--- a/src/haskell/install.sh
+++ b/src/haskell/install.sh
@@ -9,6 +9,7 @@ ADJUST_BASHRC="${ADJUSTBASH:-"true"}"
 
 INSTALL_STACK_GHCUP_HOOK="${INSTALLSTACKGHCUPHOOK:-"true"}"
 CABAL_INSTALLS=`echo "${GLOBALPACKAGES:-""}" | tr ',' ' '`
+CABAL_INSTALLS_LIBS=`echo "${GLOBALLIBRARIES:-""}" | tr ',' ' '`
 
 # Clean up
 rm -rf /var/lib/apt/lists/*
@@ -85,8 +86,15 @@ sudo -iu "$_REMOTE_USER" <<EOF
 		fi
 	fi
 
-	if [[ ! -z "${CABAL_INSTALLS}" ]]; then
-		cabal update && echo "${CABAL_INSTALLS}" | xargs cabal install
+	# Install packages & libraries with Cabal
+	if [[ -n "${CABAL_INSTALLS}${CABAL_INSTALLS_LIBS}" ]]; then
+		cabal update
+		if [[ -n "${CABAL_INSTALLS}" ]]; then
+			echo "${CABAL_INSTALLS}" | xargs cabal install
+		fi
+		if [[ -n "${CABAL_INSTALLS_LIBS}" ]]; then
+			echo "${CABAL_INSTALLS_LIBS}" | xargs cabal install --lib
+		fi
 	fi
 EOF
 

--- a/test/haskell/scenarios.json
+++ b/test/haskell/scenarios.json
@@ -4,5 +4,13 @@
         "features": {
             "haskell": {}
         }
+    },
+    "test_libraries": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "haskell": {
+                "globalLibraries": "hspec hspec-contrib QuickCheck HUnit"
+            }
+        }
     }
 }

--- a/test/haskell/scenarios.json
+++ b/test/haskell/scenarios.json
@@ -9,7 +9,7 @@
         "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "haskell": {
-                "globalLibraries": "hspec hspec-contrib QuickCheck HUnit"
+                "globalLibraries": "stm"
             }
         }
     }

--- a/test/haskell/test_libraries.sh
+++ b/test/haskell/test_libraries.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "cabal install --lib" ghc -e "import Test.Hspec; import Test.QuickCheck"
+
+reportResults

--- a/test/haskell/test_libraries.sh
+++ b/test/haskell/test_libraries.sh
@@ -4,6 +4,6 @@ set -e
 
 source dev-container-features-test-lib
 
-check "cabal install --lib" ghc -e "import Test.Hspec; import Test.QuickCheck"
+check "cabal install --lib" ghc -e "import Control.Concurrent.STM"
 
 reportResults


### PR DESCRIPTION
As discussed in devcontainers-contrib/features/issues/584 you can install either executables or libraries with Cabal. This PR fixes devcontainers-contrib/features/issues/584 and adds the option to install libraries besides executables.