### PR TITLE
chore(ci): free some storage before running tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -127,6 +127,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          docker-images: false
+          swap-storage: false
+
       - name: "Install latest devcontainer CLI"
         run: npm install -g @devcontainers/cli
 


### PR DESCRIPTION
Added [Free Disk Space (Ubuntu)](https://github.com/marketplace/actions/free-disk-space-ubuntu) GitHub Action before running the tests. It frees ~19GB of disk storage, and it should prevent some tests from failing (https://github.com/devcontainers-extra/features/pull/65#issuecomment-2452923063, https://github.com/devcontainers-extra/features/pull/52). Tested in https://github.com/devcontainers-extra/features/pull/68 [(Workflow run)](https://github.com/devcontainers-extra/features/actions/runs/11641321978/job/32419696761?pr=68)