### PR TITLE
Speeds up container build time

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,7 @@
     "ghcr.io/devcontainers/features/node:1.6.1": {},
     "ghcr.io/devcontainers/features/github-cli:1.0.13": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2.12.0": {},
+    "ghcr.io/lukewiwa/features/shellcheck:0.2.3": {},
     "ghcr.io/guiyomh/features/just:0": {},
     "ghcr.io/devcontainers-extra/features/pre-commit:2": {},
     "ghcr.io/devcontainers-extra/features/tmux-homebrew:1": {}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -7,17 +7,16 @@
         "ms-python.python",
         "ms-python.vscode-pylance",
         "DavidAnson.vscode-markdownlint",
-        "nefrob.vscode-just-syntax"
+        "nefrob.vscode-just-syntax",
+        "timonwong.shellcheck",
+        "ms-vscode-remote.remote-containers"
       ]
     }
   },
   "features": {
-    "ghcr.io/devcontainers/features/python:1.6.4": {},
-    "ghcr.io/devcontainers/features/node:1.6.0": {},
+    "ghcr.io/devcontainers/features/node:1.6.1": {},
     "ghcr.io/devcontainers/features/github-cli:1.0.13": {},
-    "ghcr.io/devcontainers/features/docker-in-docker:2.11.0": {},
-    "ghcr.io/devcontainers/features/common-utils:2.5.1": {},
-    "ghcr.io/lukewiwa/features/shellcheck:0.2.3": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2.12.0": {},
     "ghcr.io/guiyomh/features/just:0": {},
     "ghcr.io/devcontainers-extra/features/pre-commit:2": {},
     "ghcr.io/devcontainers-extra/features/tmux-homebrew:1": {}


### PR DESCRIPTION
The current devcontainer takes a long time to build. Using the Python image and getting rid of unnecessary features increases the build time dramatically.

feature          | Python image [sec] | base image [sec] | comment
-----------------|----|----|---
Python           | 0  | 75 | Redundant with the Python image
common utilities | 0  | 30 | The common utilities  feature is already included in the python image.
shellcheck       | 0  | 6  | shellcheck binaries are already installed with the shellcheck extension.
node             | 8  | 15 |
tmux             | 40 | 42 |
Docker-in-Docker | 30 | 30 |
Pre-Commit       | 8  | 6  |
GitHub-CLI       | 4  | 3  |
just             | 1  | 1  |

-- Tested on codespaces

I used the [Python image](https://github.com/devcontainers/images/blob/main/src/python/.devcontainer/devcontainer.json) with the node feature because here the node feature takes < 10 sec. When using the [javascript-node image](https://github.com/devcontainers/images/blob/main/src/javascript-node/.devcontainer/devcontainer.json) and installing the Python feature it takes longer.
The [universal image](https://github.com/devcontainers/images/blob/main/src/universal/.devcontainer/devcontainer.json) includes many features including docker-in-docker, github-cli, node and python, but it is very heavy.