### PR TITLE
Add minimal devcontainer

### DIFF
--- a/.devcontainer/min/devcontainer.json
+++ b/.devcontainer/min/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "mads-hartmann.bash-ide-vscode",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "DavidAnson.vscode-markdownlint",
+        "nefrob.vscode-just-syntax",
+        "timonwong.shellcheck",
+        "ms-vscode-remote.remote-containers"
+      ]
+    }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/node:1.6.1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2.12.0": {},
+    "ghcr.io/guiyomh/features/just:0": {},
+    "ghcr.io/devcontainers-extra/features/pre-commit:2": {}
+  },
+  "postCreateCommand": "/bin/bash -ex ./.devcontainer/setup.sh > postCreateCommand.log"
+}

--- a/.devcontainer/min/setup.sh
+++ b/.devcontainer/min/setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+npm install -g @devcontainers/cli
+
+pre-commit install --install-hooks


### PR DESCRIPTION
In addition to #71 I created an additional min devcontainer (`.devcontainer/min/`) which builds much faster, by dropping `tmux`, `shfmt` and `explainshell`. This will also drain less resources, because `explainshell` runs inside an additional container.
This devcontainer can optionally be selected besides the default devcontainer (in `.devcontainer/`) during the devcontainer creation process.