### PR TITLE
Add injections support to copier

### DIFF
--- a/src/copier/devcontainer-feature.json
+++ b/src/copier/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "copier",
-    "version": "7.0.13",
+    "version": "7.0.14",
     "name": "copier (via pipx)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/copier",
     "description": "copier creates projects from project templates.",

--- a/src/copier/devcontainer-feature.json
+++ b/src/copier/devcontainer-feature.json
@@ -12,6 +12,11 @@
                 "latest"
             ],
             "type": "string"
+        },
+        "injections": {
+            "default": "",
+            "description": "Space delimitered list of python packages to inject into the main package env.",
+            "type": "string"
         }
     },
     "installsAfter": [

--- a/src/copier/install.sh
+++ b/src/copier/install.sh
@@ -10,14 +10,13 @@ set -e
 # of the script
 ensure_nanolayer nanolayer_location "v0.5.0"
 
-
 $nanolayer_location \
     install \
     devcontainer-feature \
     "ghcr.io/devcontainers-extra/features/pipx-package:1.1.8" \
-    --option package='copier' --option version="$VERSION"
-
-
+    --option package='copier' \
+    --option version="$VERSION" \
+    --option injections="$INJECTIONS"
 
 echo 'Done!'
 

--- a/test/copier/injections.sh
+++ b/test/copier/injections.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -i
+#!/usr/bin/env bash
 
 set -e
 

--- a/test/copier/injections.sh
+++ b/test/copier/injections.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -i
+
+set -e
+
+source dev-container-features-test-lib
+
+check "copier --version" copier --version
+check "copier has jinja2-strcase extension available" bash -c 'find $(dirname $(dirname $(which jinja2))) -name "jinja2_strcase" | grep jinja2_strcase'
+
+reportResults

--- a/test/copier/injections.sh
+++ b/test/copier/injections.sh
@@ -5,6 +5,6 @@ set -e
 source dev-container-features-test-lib
 
 check "copier --version" copier --version
-check "copier has jinja2-strcase extension available" bash -c 'find $(dirname $(dirname $(which jinja2))) -name "jinja2_strcase" | grep jinja2_strcase'
+check "copier has jinja2-strcase extension available" bash -c 'find $(dirname $(dirname $(which copier))) -name "jinja2_strcase" | grep jinja2_strcase'
 
 reportResults

--- a/test/copier/scenarios.json
+++ b/test/copier/scenarios.json
@@ -4,5 +4,13 @@
         "features": {
             "copier": {}
         }
+    },
+    "injections": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "copier": {
+                "injections": "jinja2-strcase"
+            }
+        }
     }
 }


### PR DESCRIPTION
Allow `copier` to pass `injections` to pipx, so that `copier` users can add some `jinja2` extensions.