### PR TITLE
Add xdg-utils package to shopify-cli feature install script

### DIFF
--- a/src/shopify-cli/devcontainer-feature.json
+++ b/src/shopify-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "shopify-cli",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "name": "Shopify CLI (via npm)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/shopify-cli",
     "description": "Shopify CLI is a command-line interface tool that helps you build Shopify apps and themes. It quickly generates Shopify apps, themes, and custom storefronts. You can also use it to automate many common development tasks.",

--- a/src/shopify-cli/install.sh
+++ b/src/shopify-cli/install.sh
@@ -10,6 +10,20 @@ set -e
 # of the script
 ensure_nanolayer nanolayer_location "v0.5.5"
 
+if [ -x "/usr/bin/apt-get" ] ; then
+    $nanolayer_location \
+        install \
+        apt-get \
+        "xdg-utils"
+elif [ -x "/sbin/apk" ] ; then
+    $nanolayer_location \
+        install \
+        apk \
+        "xdg-utils"
+else
+    echo "Distro not supported"
+    exit 1
+fi
 
 $nanolayer_location \
     install \

--- a/src/shopify-cli/install.sh
+++ b/src/shopify-cli/install.sh
@@ -15,11 +15,6 @@ if [ -x "/usr/bin/apt-get" ] ; then
         install \
         apt-get \
         "xdg-utils"
-elif [ -x "/sbin/apk" ] ; then
-    $nanolayer_location \
-        install \
-        apk \
-        "xdg-utils"
 else
     echo "Distro not supported"
     exit 1


### PR DESCRIPTION
Shopify CLI has a dependency on xdg-open (as part of xdg-utils) in order to authenticate.

After inspecting the nanolayer source code, I discovered that it had an install command that can install apt-get and apk packages.

This pull request will install xdg-utils in the setup process.

I've opted for using the apt-get and apk check from `library_scripts.sh` rather than using the `ghcr.io/devcontainers-extra/features/apt-get-packages` feature because I don't want to create a limitation on apt-get.

See related issues:
* https://github.com/devcontainers-contrib/features/issues/632
* https://github.com/Shopify/cli/issues/3938


I created a test scenario locally, adapted from the scenario already committed from the author of the feature, but haven't included it in this commit because it requires a parameter value that could be deemed as personal info. It doesn't appear that Shopify has a public development store to run this against - or if there is, I couldn't find one.

The check needed would have been:
`check "shopify theme list" shopify theme list --store your_store_name`