### PR TITLE
fix: bump homebrew-package used during installation to 1.0.8

### DIFF
--- a/archive/src/ffmpeg-homebrew/install.sh
+++ b/archive/src/ffmpeg-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='ffmpeg' --option version="$VERSION"
 
 

--- a/src/btop-homebrew/devcontainer-feature.json
+++ b/src/btop-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "btop-homebrew",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "name": "btop (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/btop-homebrew",
     "description": "btop is a resource monitor that shows usage and stats for processor, memory, disks, network and processes.",

--- a/src/btop-homebrew/install.sh
+++ b/src/btop-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='btop' --option version="$VERSION"
 
 

--- a/src/curl-homebrew/devcontainer-feature.json
+++ b/src/curl-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "curl-homebrew",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "name": "cURL (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/curl-homebrew",
     "description": "cURL is a computer software project providing a library and command-line tool for transferring data using various network protocols.",

--- a/src/curl-homebrew/install.sh
+++ b/src/curl-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='curl' --option version="$VERSION"
 
 

--- a/src/ddgr-homebrew/devcontainer-feature.json
+++ b/src/ddgr-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "ddgr-homebrew",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "name": "ddgr (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/ddgr-homebrew",
     "description": "ddgr is a cmdline utility to search DuckDuckGo from the terminal.",

--- a/src/ddgr-homebrew/install.sh
+++ b/src/ddgr-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='ddgr' --option version="$VERSION"
 
 

--- a/src/fossil-homebrew/devcontainer-feature.json
+++ b/src/fossil-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "fossil-homebrew",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "name": "Fossil (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/fossil-homebrew",
     "description": "Fossil is a simple, high-reliability, distributed software configuration management system. It is capable of performing distributed version control, bug tracking, wiki services, and blogging.",

--- a/src/fossil-homebrew/install.sh
+++ b/src/fossil-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='fossil' --option version="$VERSION"
 
 

--- a/src/jfrog-cli-homebrew/devcontainer-feature.json
+++ b/src/jfrog-cli-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "jfrog-cli-homebrew",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "name": "JFrog CLI (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/jfrog-cli-homebrew",
     "description": "JFrog CLI is a compact and smart client that provides a simple interface that automates access to JFrog products simplifying your automation scripts making them more readable and easier to maintain.",

--- a/src/jfrog-cli-homebrew/install.sh
+++ b/src/jfrog-cli-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='jfrog-cli' --option version="$VERSION"
 
 

--- a/src/lastpass-cli-homebrew/devcontainer-feature.json
+++ b/src/lastpass-cli-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "lastpass-cli-homebrew",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "name": "LastPass CLI (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/lastpass-cli-homebrew",
     "description": "The LastPass command line application is an open source project that allows you to create, edit, and retrieve passwords in your online LastPass vault.",

--- a/src/lastpass-cli-homebrew/install.sh
+++ b/src/lastpass-cli-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='lastpass-cli' --option version="$VERSION"
 
 

--- a/src/mongodb-atlas-cli-homebrew/devcontainer-feature.json
+++ b/src/mongodb-atlas-cli-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "mongodb-atlas-cli-homebrew",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "name": "MongoDB Atlas CLI (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/mongodb-atlas-cli-homebrew",
     "description": "The Atlas CLI is a command line interface built specifically for MongoDB Atlas.",

--- a/src/mongodb-atlas-cli-homebrew/install.sh
+++ b/src/mongodb-atlas-cli-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='mongodb-atlas' --option version="$VERSION"
 
 

--- a/src/mongosh-homebrew/devcontainer-feature.json
+++ b/src/mongosh-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "mongosh-homebrew",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "name": "MongoDB Shell (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/mongosh-homebrew",
     "description": "MongoDB Shell to connect, configure, query, and work with your MongoDB database.",

--- a/src/mongosh-homebrew/install.sh
+++ b/src/mongosh-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='mongosh' --option version="$VERSION"
 
 

--- a/src/mosh-homebrew/devcontainer-feature.json
+++ b/src/mosh-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "mosh-homebrew",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "name": "Mosh (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/mosh-homebrew",
     "description": "Mosh is a remote terminal application that allows roaming, supports intermittent connectivity, and provides intelligent local echo and line editing of user keystrokes.",

--- a/src/mosh-homebrew/install.sh
+++ b/src/mosh-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='mosh' --option version="$VERSION"
 
 

--- a/src/mysql-homebrew/devcontainer-feature.json
+++ b/src/mysql-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "mysql-homebrew",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "name": "MySQL (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/mysql-homebrew",
     "description": "MySQL is an open-source relational database management system (RDBMS)",

--- a/src/mysql-homebrew/install.sh
+++ b/src/mysql-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='mysql' --option version="$VERSION"
 
 

--- a/src/neovim-homebrew/devcontainer-feature.json
+++ b/src/neovim-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "neovim-homebrew",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "name": "Neovim (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/neovim-homebrew",
     "description": "Neovim is a fork of Vim focused on modern code and features, rather than running in legacy environments.",

--- a/src/neovim-homebrew/install.sh
+++ b/src/neovim-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='neovim' --option version="$VERSION"
 
 

--- a/src/nmap-homebrew/devcontainer-feature.json
+++ b/src/nmap-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "nmap-homebrew",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "name": "Nmap (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/nmap-homebrew",
     "description": "Nmap (Network Mapper) is a free and open source utility for network discovery and security auditing.",

--- a/src/nmap-homebrew/install.sh
+++ b/src/nmap-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='nmap' --option version="$VERSION"
 
 

--- a/src/nnn-homebrew/devcontainer-feature.json
+++ b/src/nnn-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "nnn-homebrew",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "name": "nnn (n\u00b3) (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/nnn-homebrew",
     "description": "nnn is a free and open-source file manager which provides a text-based user interface to provide file managing functionalities for Unix-like systems.",

--- a/src/nnn-homebrew/install.sh
+++ b/src/nnn-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='nnn' --option version="$VERSION"
 
 

--- a/src/podman-homebrew/devcontainer-feature.json
+++ b/src/podman-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "podman-homebrew",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "name": "Podman (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/podman-homebrew",
     "description": "Podman is a tool for managing containers and images, volumes mounted into those containers, and pods made from groups of containers.",

--- a/src/podman-homebrew/install.sh
+++ b/src/podman-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='podman' --option version="$VERSION"
 
 

--- a/src/redis-homebrew/devcontainer-feature.json
+++ b/src/redis-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "redis-homebrew",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "name": "Redis (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/redis-homebrew",
     "description": "Redis is an in-memory data structure store, used as a distributed, in-memory key-value database, cache and message broker, with optional durability.",

--- a/src/redis-homebrew/install.sh
+++ b/src/redis-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='redis' --option version="$VERSION"
 
 

--- a/src/starship-homebrew/devcontainer-feature.json
+++ b/src/starship-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "starship-homebrew",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "name": "Starship (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/starship-homebrew",
     "description": "Starship is fast and highly customizable cross-shell prompt that can display contextual information.",

--- a/src/starship-homebrew/install.sh
+++ b/src/starship-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='starship' --option version="$VERSION"
 
 

--- a/src/tfenv-homebrew/devcontainer-feature.json
+++ b/src/tfenv-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "tfenv-homebrew",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "name": "tfenv (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/tfenv-homebrew",
     "description": "tfenv is an open-source Terraform version manager tool.",

--- a/src/tfenv-homebrew/install.sh
+++ b/src/tfenv-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='tfenv' --option version="$VERSION"
 
 

--- a/src/tmux-homebrew/devcontainer-feature.json
+++ b/src/tmux-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "tmux-homebrew",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "name": "tmux (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/tmux-homebrew",
     "description": "tmux is a terminal multiplexer: it enables a number of terminals to be created, accessed, and controlled from a single screen. tmux may be detached from a screen and continue running in the background, then later reattached.",

--- a/src/tmux-homebrew/install.sh
+++ b/src/tmux-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='tmux' --option version="$VERSION"
 
 

--- a/src/w3m-homebrew/devcontainer-feature.json
+++ b/src/w3m-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "w3m-homebrew",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "name": "w3m (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/w3m-homebrew",
     "description": "w3m is a free software/open source text-based web browser and terminal pager.",

--- a/src/w3m-homebrew/install.sh
+++ b/src/w3m-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='w3m' --option version="$VERSION"
 
 

--- a/src/wget-homebrew/devcontainer-feature.json
+++ b/src/wget-homebrew/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "wget-homebrew",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "name": "Wget (via Homebrew)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/wget-homebrew",
     "description": "Wget is a free software package for retrieving files using HTTP, HTTPS, FTP and FTPS, the most widely used Internet protocols.",

--- a/src/wget-homebrew/install.sh
+++ b/src/wget-homebrew/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.4.39"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7" \
+    "ghcr.io/devcontainers-extra/features/homebrew-package:1.0.8" \
     --option package='wget' --option version="$VERSION"
 
 


### PR DESCRIPTION
The features that use `ghcr.io/devcontainers-extra/features/homebrew-package:1.0.7` are failing, as it's missing. Bumping its version to `1.0.8` which is present, should fix the issue