### PR TITLE
Added possibility to inject packages into the ansible pipx package

### DIFF
--- a/src/ansible/README.md
+++ b/src/ansible/README.md
@@ -16,6 +16,7 @@ Ansible is a suite of software tools that enables infrastructure as code.
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
 | version | Select the version to install. | string | latest |
+| injections | Space delimitered list of python packages to inject into the main package env | string | - |
 
 
 

--- a/src/ansible/devcontainer-feature.json
+++ b/src/ansible/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "ansible",
-    "version": "2.0.17",
+    "version": "2.1.0",
     "name": "Ansible (via pipx)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/ansible",
     "description": "Ansible is a suite of software tools that enables infrastructure as code.",
@@ -10,6 +10,15 @@
             "description": "Select the version to install.",
             "proposals": [
                 "latest"
+            ],
+            "type": "string"
+        },
+        "injections": {
+            "default": "",
+            "description": "Space delimitered list of python packages to inject into the ansible package env",
+            "proposals": [
+                "hcloud",
+                "hcloud requests"
             ],
             "type": "string"
         }

--- a/src/ansible/install.sh
+++ b/src/ansible/install.sh
@@ -13,6 +13,6 @@ $nanolayer_location \
     install \
     devcontainer-feature \
     "ghcr.io/devcontainers-extra/features/pipx-package:1.1.9" \
-    --option package='ansible-core' --option injections='ansible' --option version="$VERSION"
+    --option package='ansible' --option injections="$INJECTIONS" --option version="$VERSION" --option includeDeps="true"
 
 echo 'Done!'

--- a/src/ansible/install.sh
+++ b/src/ansible/install.sh
@@ -13,6 +13,6 @@ $nanolayer_location \
     install \
     devcontainer-feature \
     "ghcr.io/devcontainers-extra/features/pipx-package:1.1.9" \
-    --option package='ansible' --option injections="$INJECTIONS" --option version="$VERSION" --option includeDeps="true"
+    --option package='ansible-core' --option injections="$INJECTIONS" --option version="$VERSION" --option includeDeps="true"
 
 echo 'Done!'

--- a/src/ansible/install.sh
+++ b/src/ansible/install.sh
@@ -13,6 +13,6 @@ $nanolayer_location \
     install \
     devcontainer-feature \
     "ghcr.io/devcontainers-extra/features/pipx-package:1.1.9" \
-    --option package='ansible-core' --option injections="$INJECTIONS" --option version="$VERSION" --option includeDeps="true"
+    --option package='ansible-core' --option injections="ansible $INJECTIONS" --option version="$VERSION" --option includeDeps="true"
 
 echo 'Done!'

--- a/test/ansible/scenarios.json
+++ b/test/ansible/scenarios.json
@@ -24,5 +24,13 @@
                 "version": "2.13.0"
             }
         }
+    },
+    "test_injections": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "ansible": {
+                "injections": "hcloud"
+            }
+        }
     }
 }

--- a/test/ansible/test_injections.sh
+++ b/test/ansible/test_injections.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "hcloud package is injected" bash -c "pipx list --include-injected | grep hcloud"
+
+reportResults


### PR DESCRIPTION
There are some ansible addon packages like the Hetzner inventory plugins needs to be installed into the ansible venv.

Currently the ansible package doesn't support installing ansible plugins.

I am also including dependencies now.