### PR TITLE
Add VS Code extension to the Ruff feature

### DIFF
--- a/src/ruff/devcontainer-feature.json
+++ b/src/ruff/devcontainer-feature.json
@@ -14,6 +14,13 @@
             "type": "string"
         }
     },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "charliermarsh.ruff"
+            ]
+        }
+    },
     "installsAfter": [
         "ghcr.io/devcontainers-extra/features/pipx-package",
         "ghcr.io/devcontainers/features/python"

--- a/src/ruff/devcontainer-feature.json
+++ b/src/ruff/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "ruff",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "name": "Ruff (via pipx)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/ruff",
     "description": "Ruff is an extremely fast Python linter, written in Rust.",


### PR DESCRIPTION
Automatically install the Ruff extension in VS Code when using the Ruff feature. This is what the official Python feature does with the Python extension.