### PR TITLE
Add feature ocaml-opam

### DIFF
--- a/src/ocaml-opam/devcontainer-feature.json
+++ b/src/ocaml-opam/devcontainer-feature.json
@@ -14,6 +14,11 @@
                 "4.14.2"
             ],
             "type": "string"
+        },
+        "installPlatformTools": {
+            "default": true,
+            "description": "Install some of the OCaml Platform tools? (UTop, Dune, OCaml-LSP, odoc, OCamlFormat)",
+            "type": "boolean"
         }
     },
     "customizations": {

--- a/src/ocaml-opam/devcontainer-feature.json
+++ b/src/ocaml-opam/devcontainer-feature.json
@@ -1,0 +1,29 @@
+{
+    "id": "ocaml-opam",
+    "version": "1.0.0",
+    "name": "OCaml (via opam)",
+    "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/ocaml-opam",
+    "description": "Installation of OCaml that includes a package manager and the compiler itself. Also install some platform tools like a build system, support for your editor, and a few other important ones.",
+    "options": {
+        "version": {
+            "default": "latest",
+            "description": "Select the OCaml version to install.",
+            "proposals": [
+                "latest",
+                "5.3.0",
+                "4.14.2"
+            ],
+            "type": "string"
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ocamllabs.ocaml-platform"
+            ]
+        }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers-extra/features/gh-release"
+    ]
+}

--- a/src/ocaml-opam/install.sh
+++ b/src/ocaml-opam/install.sh
@@ -16,7 +16,7 @@ $nanolayer_location \
     install \
     devcontainer-feature \
     "ghcr.io/devcontainers-extra/features/gh-release:1" \
-    --option repo='ocaml/opam' --option binaryNames='opam' --option version="latest"
+    --option repo='ocaml/opam' --option binaryNames='opam' --option version="latest" --option releaseTagRegex='^(?!.*(alpha|beta|rc)).*$'
 
 
 # Initialise opam

--- a/src/ocaml-opam/install.sh
+++ b/src/ocaml-opam/install.sh
@@ -20,13 +20,16 @@ $nanolayer_location \
 
 
 # Initialise opam
-if [ "$VERSION" = "latest" ]; then
-    su "$_REMOTE_USER" -c "opam init --disable-sandboxing --shell-setup -y"
-else
-    su "$_REMOTE_USER" -c "opam init --disable-sandboxing --shell-setup -y --compiler=\"$VERSION\""
+flags=()
+if [ "$VERSION" != "latest" ]; then
+    flags+=(--compiler="$VERSION")
 fi
+su "$_REMOTE_USER" -c "opam init --disable-sandboxing --shell-setup -y ${flags[*]}"
+
 # Install Platform Tools
-su "$_REMOTE_USER" -c "opam install ocaml-lsp-server odoc ocamlformat utop -y"
+if [ "$INSTALLPLATFORMTOOLS" = "true" ]; then
+    su "$_REMOTE_USER" -c "opam install ocaml-lsp-server odoc ocamlformat utop -y"
+fi
 
 
 echo 'Done!'

--- a/src/ocaml-opam/install.sh
+++ b/src/ocaml-opam/install.sh
@@ -15,7 +15,7 @@ ensure_nanolayer nanolayer_location "v0.5.6"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/gh-release:1" \
+    "ghcr.io/devcontainers-extra/features/gh-release:1.0.25" \
     --option repo='ocaml/opam' --option binaryNames='opam' --option version="latest" --option releaseTagRegex='^(?!.*(alpha|beta|rc)).*$'
 
 

--- a/src/ocaml-opam/install.sh
+++ b/src/ocaml-opam/install.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+source ./library_scripts.sh
+
+# nanolayer is a cli utility which keeps container layers as small as possible
+# source code: https://github.com/devcontainers-extra/nanolayer
+# `ensure_nanolayer` is a bash function that will find any existing nanolayer installations,
+# and if missing - will download a temporary copy that automatically get deleted at the end
+# of the script
+ensure_nanolayer nanolayer_location "v0.5.6"
+
+# Example nanolayer installation via devcontainer-feature
+$nanolayer_location \
+    install \
+    devcontainer-feature \
+    "ghcr.io/devcontainers-extra/features/gh-release:1" \
+    --option repo='ocaml/opam' --option binaryNames='opam' --option version="latest"
+
+
+# Initialise opam
+if [ "$VERSION" = "latest" ]; then
+    su "$_REMOTE_USER" -c "opam init --disable-sandboxing --shell-setup -y"
+else
+    su "$_REMOTE_USER" -c "opam init --disable-sandboxing --shell-setup -y --compiler=\"$VERSION\""
+fi
+# Install Platform Tools
+su "$_REMOTE_USER" -c "opam install ocaml-lsp-server odoc ocamlformat utop -y"
+
+
+echo 'Done!'

--- a/src/ocaml-opam/library_scripts.sh
+++ b/src/ocaml-opam/library_scripts.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+
+clean_download() {
+    # The purpose of this function is to download a file with minimal impact on container layer size
+    # this means if no valid downloader is found (curl or wget) then we install a downloader (currently wget) in a
+    # temporary manner, and making sure to
+    # 1. uninstall the downloader at the return of the function
+    # 2. revert back any changes to the package installer database/cache (for example apt-get lists)
+    # The above steps will minimize the leftovers being created while installing the downloader
+    # Supported distros:
+    #  debian/ubuntu/alpine
+
+    url=$1
+    output_location=$2
+    tempdir=$(mktemp -d)
+    downloader_installed=""
+
+    function _apt_get_install() {
+        tempdir=$1
+
+        # copy current state of apt list - in order to revert back later (minimize contianer layer size)
+        cp -p -R /var/lib/apt/lists $tempdir
+        apt-get update -y
+        apt-get -y install --no-install-recommends wget ca-certificates
+    }
+
+    function _apt_get_cleanup() {
+        tempdir=$1
+
+        echo "removing wget"
+        apt-get -y purge wget --auto-remove
+
+        echo "revert back apt lists"
+        rm -rf /var/lib/apt/lists/*
+        rm -r /var/lib/apt/lists && mv $tempdir/lists /var/lib/apt/lists
+    }
+
+    function _apk_install() {
+        tempdir=$1
+        # copy current state of apk cache - in order to revert back later (minimize contianer layer size)
+        cp -p -R /var/cache/apk $tempdir
+
+        apk add --no-cache wget
+    }
+
+    function _apk_cleanup() {
+        tempdir=$1
+
+        echo "removing wget"
+        apk del wget
+    }
+    # try to use either wget or curl if one of them already installer
+    if type curl >/dev/null 2>&1; then
+        downloader=curl
+    elif type wget >/dev/null 2>&1; then
+        downloader=wget
+    else
+        downloader=""
+    fi
+
+    # in case none of them is installed, install wget temporarly
+    if [ -z $downloader ]; then
+        if [ -x "/usr/bin/apt-get" ]; then
+            _apt_get_install $tempdir
+        elif [ -x "/sbin/apk" ]; then
+            _apk_install $tempdir
+        else
+            echo "distro not supported"
+            exit 1
+        fi
+        downloader="wget"
+        downloader_installed="true"
+    fi
+
+    if [ $downloader = "wget" ]; then
+        wget -q $url -O $output_location
+    else
+        curl -sfL $url -o $output_location
+    fi
+
+    # NOTE: the cleanup procedure was not implemented using `trap X RETURN` only because
+    # alpine lack bash, and RETURN is not a valid signal under sh shell
+    if ! [ -z $downloader_installed ]; then
+        if [ -x "/usr/bin/apt-get" ]; then
+            _apt_get_cleanup $tempdir
+        elif [ -x "/sbin/apk" ]; then
+            _apk_cleanup $tempdir
+        else
+            echo "distro not supported"
+            exit 1
+        fi
+    fi
+
+}
+
+ensure_nanolayer() {
+    # Ensure existance of the nanolayer cli program
+    local variable_name=$1
+
+    local required_version=$2
+    # normalize version
+    if ! [[ $required_version == v* ]]; then
+        required_version=v$required_version
+    fi
+
+    local nanolayer_location=""
+
+    # If possible - try to use an already installed nanolayer
+    if [[ -z "${NANOLAYER_FORCE_CLI_INSTALLATION}" ]]; then
+        if [[ -z "${NANOLAYER_CLI_LOCATION}" ]]; then
+            if type nanolayer >/dev/null 2>&1; then
+                echo "Found a pre-existing nanolayer in PATH"
+                nanolayer_location=nanolayer
+            fi
+        elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ]; then
+            nanolayer_location=${NANOLAYER_CLI_LOCATION}
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
+        fi
+
+        # make sure its of the required version
+        if ! [[ -z "${nanolayer_location}" ]]; then
+            local current_version
+            current_version=$($nanolayer_location --version)
+            if ! [[ $current_version == v* ]]; then
+                current_version=v$current_version
+            fi
+
+            if ! [ $current_version == $required_version ]; then
+                echo "skipping usage of pre-existing nanolayer. (required version $required_version does not match existing version $current_version)"
+                nanolayer_location=""
+            fi
+        fi
+
+    fi
+
+    # If not previuse installation found, download it temporarly and delete at the end of the script
+    if [[ -z "${nanolayer_location}" ]]; then
+
+        if [ "$(uname -sm)" == "Linux x86_64" ] || [ "$(uname -sm)" == "Linux aarch64" ]; then
+            tmp_dir=$(mktemp -d -t nanolayer-XXXXXXXXXX)
+
+            clean_up() {
+                ARG=$?
+                rm -rf $tmp_dir
+                exit $ARG
+            }
+            trap clean_up EXIT
+
+            if [ -x "/sbin/apk" ]; then
+                clib_type=musl
+            else
+                clib_type=gnu
+            fi
+
+            tar_filename=nanolayer-"$(uname -m)"-unknown-linux-$clib_type.tgz
+
+            # clean download will minimize leftover in case a downloaderlike wget or curl need to be installed
+            clean_download https://github.com/devcontainers-extra/nanolayer/releases/download/$required_version/$tar_filename $tmp_dir/$tar_filename
+
+            tar xfzv $tmp_dir/$tar_filename -C "$tmp_dir"
+            chmod a+x $tmp_dir/nanolayer
+            nanolayer_location=$tmp_dir/nanolayer
+
+        else
+            echo "No binaries compiled for non-x86-linux architectures yet: $(uname -m)"
+            exit 1
+        fi
+    fi
+
+    # Expose outside the resolved location
+    declare -g ${variable_name}=$nanolayer_location
+
+}

--- a/test/ocaml-opam/scenarios.json
+++ b/test/ocaml-opam/scenarios.json
@@ -12,5 +12,13 @@
                 "version": "4.14.2"
             }
         }
+    },
+    "test_no_platform_tools": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "ocaml-opam": {
+                "installPlatformTools": false
+            }
+        }
     }
 }

--- a/test/ocaml-opam/scenarios.json
+++ b/test/ocaml-opam/scenarios.json
@@ -1,0 +1,16 @@
+{
+    "test_debian": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "ocaml-opam": {}
+        }
+    },
+    "test_specific_version": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "ocaml-opam": {
+                "version": "4.14.2"
+            }
+        }
+    }
+}

--- a/test/ocaml-opam/test.sh
+++ b/test/ocaml-opam/test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "something is installed" something --version
+
+reportResults

--- a/test/ocaml-opam/test.sh
+++ b/test/ocaml-opam/test.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-source dev-container-features-test-lib
-
-check "something is installed" something --version
-
-reportResults

--- a/test/ocaml-opam/test_debian.sh
+++ b/test/ocaml-opam/test_debian.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "opam is installed" opam --version
+check "OCaml is installed" ocamlc --version
+
+# TODO: check "[WARNING] The environment is not in sync with the current switch." not present
+
+reportResults

--- a/test/ocaml-opam/test_debian.sh
+++ b/test/ocaml-opam/test_debian.sh
@@ -7,6 +7,6 @@ source dev-container-features-test-lib
 check "opam is installed" opam --version
 check "OCaml is installed" ocamlc --version
 
-# TODO: check "[WARNING] The environment is not in sync with the current switch." not present
+check "no opam warning" sh -c "test $(opam switch 2>&1 | grep --count 'WARNING') -eq 0"
 
 reportResults

--- a/test/ocaml-opam/test_debian.sh
+++ b/test/ocaml-opam/test_debian.sh
@@ -6,6 +6,7 @@ source dev-container-features-test-lib
 
 check "opam is installed" opam --version
 check "OCaml is installed" ocamlc --version
+check "UTop is installed" utop -version
 
 check "no opam warning" sh -c "test $(opam switch 2>&1 | grep --count 'WARNING') -eq 0"
 

--- a/test/ocaml-opam/test_no_platform_tools.sh
+++ b/test/ocaml-opam/test_no_platform_tools.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "no utop" sh -c "! command -v utop"
+
+reportResults

--- a/test/ocaml-opam/test_specific_version.sh
+++ b/test/ocaml-opam/test_specific_version.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "OCaml version is equal to 4.14.2" sh -c "ocamlc --version | grep '4.14.2'"
+
+reportResults


### PR DESCRIPTION
I know that ocaml-asdf and opam-asdf already exist, but:

- I don't want to use OCaml without opam
- opam-asdf only installs opam, then I have to initialize it, then install OCaml
- they don't include convenient things like the build system, an LSP, the VS Code extension, etc.
- I don't know what asdf is, so I don't really want to use it :sweat_smile:

Both seem auto-generated, with no real intention of providing a usable development environment out of the box.

I started from scratch, following the installation process given on the OCaml site.

---

I still have a few details to work out:

- [x] gh-release doesn't download the latest version of opam
- [x] platform tools are systematically installed; this should be disableable
- [ ] if the project uses opam as a dependency manager (which is likely), have an option to pre-install the project's dependencies

I don't know if I should publish it and improve it later, or keep it as a draft until I've solved these details?