### PR TITLE
fix(npm-packages): handle scoped npm packages with format @package or…

### DIFF
--- a/src/npm-packages/devcontainer-feature.json
+++ b/src/npm-packages/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "npm-packages",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "npm-packages",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/npm-packages",
     "description": "",

--- a/src/npm-packages/install.sh
+++ b/src/npm-packages/install.sh
@@ -16,13 +16,16 @@ IFS=',' read -ra PACKAGE_ARRAY <<<"$PACKAGES"
 
 # Iterate through each package
 for package in "${PACKAGE_ARRAY[@]}"; do
-    # Check if package contains version
-    if [[ $package == *@* ]]; then
-        # Split package into name and version
-        name=${package%@*}
-        version=${package#*@}
+    # Use regex to match valid npm package identifier
+    # unscoped, unscoped@version, @scoped, @scoped@version
+    if [[ $package =~ ^(@?[^@]+?)(@(.+?))?$ ]]; then
+        name="${BASH_REMATCH[1]}"
+        version="${BASH_REMATCH[3]}"
+        # Bash doesn't have non-capturing groups so @version portion can
+        # only be made optional inside a group, then a nested group captures
+        # the version number itself.
     else
-        # Package without version
+        # Fallback for any invalid package identifiers
         name=$package
         version=""
     fi

--- a/test/npm-packages/scenarios.json
+++ b/test/npm-packages/scenarios.json
@@ -3,7 +3,7 @@
         "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "npm-packages": {
-                "packages": "eslint@9.20.1,nodemon,prettier@3.5.2,@moonrepo/cli@1.34.0,@biomejs/biome"
+                "packages": "eslint@9.20.1,nodemon,prettier@3.5.2,@angular/cli@19.2.1,@biomejs/biome"
             }
         }
     }

--- a/test/npm-packages/scenarios.json
+++ b/test/npm-packages/scenarios.json
@@ -3,7 +3,7 @@
         "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "npm-packages": {
-                "packages": "eslint@9.20.1,nodemon,prettier@3.5.2"
+                "packages": "eslint@9.20.1,nodemon,prettier@3.5.2,@moonrepo/cli@1.34.0,@biomejs/biome"
             }
         }
     }

--- a/test/npm-packages/test_debian_versions.sh
+++ b/test/npm-packages/test_debian_versions.sh
@@ -7,7 +7,7 @@ source dev-container-features-test-lib
 check "eslint version is equal to 9.20.1" bash -c "eslint --version | grep 'v9.20.1'"
 check "nodemon is installed" nodemon --version
 check "prettier version is equal to 3.5.2" bash -c "prettier --version | grep '3.5.2'"
-check "@moonrepo/cli version is equal to 1.34.0" bash -c "moonrepo --version | grep 1.34.0"
+check "@moonrepo/cli version is equal to 1.34.0" bash -c "moon --version | grep 1.34.0"
 check "@biomejs/biome is installed" biome --version
 
 reportResults

--- a/test/npm-packages/test_debian_versions.sh
+++ b/test/npm-packages/test_debian_versions.sh
@@ -7,7 +7,7 @@ source dev-container-features-test-lib
 check "eslint version is equal to 9.20.1" bash -c "eslint --version | grep 'v9.20.1'"
 check "nodemon is installed" nodemon --version
 check "prettier version is equal to 3.5.2" bash -c "prettier --version | grep '3.5.2'"
-check "@moonrepo/cli version is equal to 1.34.0" bash -c "moon --version | grep '1.34.0'"
+check "@angular/cli version is equal to 19.2.1" bash -c "ng --version | grep '19.2.1'"
 check "@biomejs/biome is installed" biome --version
 
 reportResults

--- a/test/npm-packages/test_debian_versions.sh
+++ b/test/npm-packages/test_debian_versions.sh
@@ -7,5 +7,7 @@ source dev-container-features-test-lib
 check "eslint version is equal to 9.20.1" bash -c "eslint --version | grep 'v9.20.1'"
 check "nodemon is installed" nodemon --version
 check "prettier version is equal to 3.5.2" bash -c "prettier --version | grep '3.5.2'"
+check "@moonrepo/cli version is equal to 1.34.0" bash -c "moonrepo --version | grep 1.34.0"
+check "@biomejs/biome is installed" biome --version
 
 reportResults

--- a/test/npm-packages/test_debian_versions.sh
+++ b/test/npm-packages/test_debian_versions.sh
@@ -7,7 +7,7 @@ source dev-container-features-test-lib
 check "eslint version is equal to 9.20.1" bash -c "eslint --version | grep 'v9.20.1'"
 check "nodemon is installed" nodemon --version
 check "prettier version is equal to 3.5.2" bash -c "prettier --version | grep '3.5.2'"
-check "@moonrepo/cli version is equal to 1.34.0" bash -c "moon --version | grep 1.34.0"
+check "@moonrepo/cli version is equal to 1.34.0" bash -c "moon --version | grep '1.34.0'"
 check "@biomejs/biome is installed" biome --version
 
 reportResults


### PR DESCRIPTION
Following on from #104 and building on the PR #110 (that seems stalled), this change supports the following package specification:

- `package`
- `package@version`
- `@package`
- `@package@version`
