### PR TITLE
PR: Add Bun Package Helper (bun-package)

### DIFF
--- a/src/bun-package/NOTES.md
+++ b/src/bun-package/NOTES.md
@@ -1,0 +1,71 @@
+# Additional Notes
+
+- Requires Bun to be installed (e.g., via the `bun` feature).
+- Exports `BUN_INSTALL=/usr/local` to ensure global binaries land in `/usr/local/bin`.
+- Useful for installing tools distributed as Bun packages (e.g., `@vercel/turbo`).
+- Accepts both bare names and `npm:`-prefixed names; Bun defaults to npm registry, so `npm:` is optional.
+
+## Behavior
+
+- Requires root to install globally to `/usr/local` (matches other package helper features).
+- Skip-if-installed:
+  - For `version: "latest"` (or empty), skips when the package is already present in `bun pm -l`.
+  - For pinned installs (e.g., `"version": "1.2.3"`), skips only when the exact `<name>@<version>` is already installed.
+- For non-npm specs (git / URL / GitHub shorthand), use `nameHint` if the name shown by `bun pm -l` differs from your install spec.
+
+## Usage Examples
+
+Default latest:
+
+```json
+"features": {
+  "ghcr.io/devcontainers-extra/features/bun-package:1": {
+    "package": "@vercel/turbo"
+  }
+}
+```
+
+Pinned version:
+
+```json
+"features": {
+  "ghcr.io/devcontainers-extra/features/bun-package:1": {
+    "package": "@vercel/turbo",
+    "version": "2.5.6"
+  }
+}
+```
+
+## Non-npm sources
+
+- Supports any spec Bun accepts in `bun add`, including git URLs (e.g., `git+https://...`), GitHub shorthand (e.g., `github:user/repo`), and tarball URLs.
+- For non-npm sources, the name shown in `bun pm -l` may not match the install spec. Use the optional `nameHint` option to tell the feature which name to look for when deciding to skip.
+
+### Non-NPM Usage Examples
+
+```json
+"features": {
+  "ghcr.io/devcontainers-extra/features/bun:1": {},
+  "ghcr.io/devcontainers-extra/features/bun-package:1": {
+    "package": "git+https://github.com/user/tool.git",
+    "nameHint": "tool"
+  }
+}
+```
+
+```json
+"features": {
+  "ghcr.io/devcontainers-extra/features/bun:1": {},
+  "ghcr.io/devcontainers-extra/features/bun-package:1": {
+    "package": "github:user/repo",
+    "nameHint": "repo"
+  }
+}
+```
+
+Note: Private registries (e.g., GitHub Packages, Artifactory) may require registry / auth setup via `.npmrc` or Bun config in the container.
+
+## Support
+
+- Distros: `Debian` / `Ubuntu` and `Alpine`
+- Architectures: `x86_64` and `arm64`

--- a/src/bun-package/README.md
+++ b/src/bun-package/README.md
@@ -1,0 +1,26 @@
+# Bun package (bun-package)
+
+Installs a Bun package globally using Bun. Ensures system-wide bin availability.
+
+## Example Usage
+
+```json
+"features": {
+  "ghcr.io/devcontainers-extra/features/bun-package:1": {
+    "package": "@vercel/turbo",
+    "version": "latest"
+  }
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| package | Select the Bun package to install globally. | string |  |
+| version | Select the version of the Bun package to install. | string | latest |
+| nameHint | Optional: name to use for skip checks (useful for git / URL / non-npm sources). | string |  |
+
+---
+
+_Note: This file was auto-generated from the [devcontainer-feature.json](devcontainer-feature.json).  Add additional notes to a `NOTES.md`._

--- a/src/bun-package/devcontainer-feature.json
+++ b/src/bun-package/devcontainer-feature.json
@@ -1,0 +1,30 @@
+{
+    "id": "bun-package",
+    "version": "1.0.0",
+    "name": "Bun package",
+    "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/bun-package",
+    "description": "Installs a Bun package globally using Bun.",
+    "options": {
+        "package": {
+            "default": "",
+            "description": "Select the Bun package to install globally.",
+            "type": "string"
+        },
+        "version": {
+            "default": "latest",
+            "description": "Select the version of the Bun package to install.",
+            "proposals": [
+                "latest"
+            ],
+            "type": "string"
+        },
+        "nameHint": {
+            "default": "",
+            "description": "Optional: name to use for skip install checks (useful for git / URL / non-npm sources).",
+            "type": "string"
+        }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers-extra/features/bun"
+    ]
+}

--- a/src/bun-package/install.sh
+++ b/src/bun-package/install.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+set -e
+
+PACKAGE=${PACKAGE:-""}
+VERSION=${VERSION:-"latest"}
+NAMEHINT=${NAMEHINT:-""}
+
+if [ -z "$PACKAGE" ]; then
+    echo "'package' option is empty, skipping"
+    exit 0
+fi
+
+# Require root (global install to /usr/local)
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as\n    root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Ensure bun exists
+if ! command -v bun >/dev/null 2>&1; then
+    echo "Bun is required. Ensure a Bun feature (bun) ran before this feature."
+    exit 1
+fi
+
+# Ensure global binaries land in /usr/local/bin
+export BUN_INSTALL="/usr/local"
+
+# Normalize optional npm: prefix; Bun defaults to npm registry
+base_pkg="$PACKAGE"
+if [[ "$base_pkg" == npm:* ]]; then
+    base_pkg="${base_pkg#npm:}"
+fi
+
+# Name used for skip checks (helps for git / URL / non-npm registry installs)
+skip_name="$base_pkg"
+if [ -n "$NAMEHINT" ]; then
+    skip_name="$NAMEHINT"
+fi
+
+# Resolve list command (prefer global). Bun uses 'pm ls'. If unavailable, skip detection.
+list_cmd=""
+if bun pm ls -g >/dev/null 2>&1; then
+    list_cmd="bun pm ls -g"
+elif bun pm ls >/dev/null 2>&1; then
+    list_cmd="bun pm ls"
+fi
+
+# Skip when already present
+if [ -n "$list_cmd" ]; then
+    if [ "$VERSION" = "latest" ] || [ -z "$VERSION" ]; then
+        if $list_cmd | grep -q "$skip_name"; then
+            echo "$skip_name already exists - skipping installation"
+            exit 0
+        fi
+    else
+        # For pinned versions, skip only if exact version already installed
+        if $list_cmd | grep -q "${skip_name}@${VERSION}"; then
+            echo "$skip_name@${VERSION} already exists - skipping installation"
+            exit 0
+        fi
+    fi
+fi
+
+# Compose installation spec
+pkg="$base_pkg"
+if [ "$VERSION" != "latest" ] && [ -n "$VERSION" ]; then
+    pkg="$base_pkg@$VERSION"
+fi
+
+# Install globally via Bun with basic retries to handle transient registry errors (e.g., 5xx)
+max_attempts=4
+attempt=1
+while true; do
+    if bun add --global "$pkg"; then
+        break
+    fi
+    exit_code=$?
+    if [ "$attempt" -ge "$max_attempts" ]; then
+        echo "bun add failed after ${attempt} attempts (exit code $exit_code)"
+        exit "$exit_code"
+    fi
+    sleep_seconds=$(( attempt * attempt ))
+    echo "bun add failed (exit code $exit_code). Retrying in ${sleep_seconds}s... (${attempt}/${max_attempts})"
+    sleep "$sleep_seconds"
+    attempt=$(( attempt + 1 ))
+done
+
+echo 'Done!'

--- a/test/bun-package/scenarios.json
+++ b/test/bun-package/scenarios.json
@@ -1,0 +1,62 @@
+{
+    "test_install_angular_cli": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "bun": {},
+            "bun-package": {
+                "version": "latest",
+                "package": "@angular/cli"
+            }
+        }
+    },
+    "test_install_typescript": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "bun": {},
+            "bun-package": {
+                "version": "latest",
+                "package": "typescript"
+            }
+        }
+    },
+    "test_ubuntu": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "bun": {},
+            "bun-package": {
+                "version": "latest",
+                "package": "typescript"
+            }
+        }
+    },
+    "test_debian": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "bun": {},
+            "bun-package": {
+                "version": "latest",
+                "package": "typescript"
+            }
+        }
+    },
+    "test_alpine": {
+        "image": "mcr.microsoft.com/devcontainers/base:alpine",
+        "features": {
+            "bun": {},
+            "bun-package": {
+                "version": "latest",
+                "package": "typescript"
+            }
+        }
+    },
+    "test_specific_package_version": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "bun": {},
+            "bun-package": {
+                "version": "5.5.4",
+                "package": "typescript"
+            }
+        }
+    }
+}

--- a/test/bun-package/test_alpine.sh
+++ b/test/bun-package/test_alpine.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "typescript is installed on Alpine (via bun-package)" bunx tsc --version
+
+reportResults

--- a/test/bun-package/test_debian.sh
+++ b/test/bun-package/test_debian.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "typescript is installed on Debian (via bun-package)" bunx tsc --version
+
+reportResults

--- a/test/bun-package/test_install_angular_cli.sh
+++ b/test/bun-package/test_install_angular_cli.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "Angular CLI is installed (via bun-package)" bunx ng version
+
+reportResults

--- a/test/bun-package/test_install_typescript.sh
+++ b/test/bun-package/test_install_typescript.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "typescript is installed (via bun-package)" bunx tsc --version
+
+reportResults

--- a/test/bun-package/test_specific_package_version.sh
+++ b/test/bun-package/test_specific_package_version.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "typescript version is equal to 5.5.4" sh -c "bunx tsc --version | grep '^Version 5.5.4'"
+
+reportResults

--- a/test/bun-package/test_ubuntu.sh
+++ b/test/bun-package/test_ubuntu.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "typescript is installed on Ubuntu (via bun-package)" bunx tsc --version
+
+reportResults


### PR DESCRIPTION
# Summary

- Add `bun-package`: Installs a single package globally via Bun.
- Provide parity with the existing `npm-package` helper while following Bun best practices.
- Add tests for Debian / Ubuntu / Alpine installs and a pinned-version scenario.

## Motivation

- Offer first-class package installation helpers for Bun, mirroring the existing npm helper features to streamline internal reuse and user workflows.
- Keep behavior consistent with repository standards and helper-first patterns, with small layers and clear skip semantics.

## Features Added

- `src/bun-package/`
  - Purpose: Install a single package globally via Bun.
  - Behavior:
    - Exports `BUN_INSTALL=/usr/local` so binaries land in `/usr/local/bin`.
    - Accepts bare names and optional `npm:`-prefixed names (Bun defaults to npm registry).
    - Skip-if-installed semantics:
      - For `latest` installs, skips when package already present.
      - For pinned installs, skips only when exact `<name>@<version>` is present.
    - Supports non-npm specs (git/URL/GitHub shorthand); `nameHint` assists skip checks when the displayed name differs.
    - Includes basic retry logic around `bun add` to mitigate transient registry 5xx errors.
    - Requires Bun to be present (via `bun` feature); `installsAfter` references `bun`.
  - Options:
    - `package`: string (required)
    - `version`: string (default `latest`)
    - `nameHint`: string (optional)

## Intended Use

- `bun-package`: Helper-oriented, ideal for downstream features to install a single tool or for precise control (incl. non-npm specs using `nameHint`).

## Usage Examples

- Single package (latest):

```json
"features": {
  "ghcr.io/devcontainers-extra/features/bun:1": {},
  "ghcr.io/devcontainers-extra/features/bun-package:1": {
    "package": "@vercel/turbo"
  }
}
```

- Single package (pinned):

```json
"features": {
  "ghcr.io/devcontainers-extra/features/bun:1": {},
  "ghcr.io/devcontainers-extra/features/bun-package:1": {
    "package": "@vercel/turbo",
    "version": "2.5.6"
  }
}
```

  

## Tests

- Scenarios (bun-package):
  - Debian/Ubuntu/Alpine TypeScript install (latest)
  - Angular CLI install
  - Pinned install: TypeScript `5.5.4` (asserts reported version)

Note: Existing-package installation testing scenarios for bun-package are deferred for now (difficult to model a preinstalled global package in a clean base image without a published multi-package helper). They can be re-enabled later once a reliable path is available / a future bun-packages multi-package installer feature is available to fill that gap.

## Docs

- Auto-generated README for the feature.
- `NOTES.md` for bun-package includes:
  - Optional `npm:` prefix usage
  - Behavior and skip semantics
  - Non-npm sources and `nameHint`

## Compatibility

- Coexists with Node / npm helper features.
- Global installs target `/usr/local/bin` for consistent PATH.

## Security/Robustness

- `nanolayer` usage keeps layers small where applicable.
- No unnecessary PATH / profile mutations; relies on Bun defaults with explicit `BUN_INSTALL`.
- Adds retry / backoff around `bun add` to reduce flakiness from transient registry errors.

## Checklist

- Code matches project style; helpers used where applicable
- Metadata (`devcontainer-feature.json`) includes options and `installsAfter`
- Tests cover Debian / Ubuntu / Alpine installs and pinned version scenario
- Lints are clean