### PR TITLE
feat: add uv-tool feature for installing Python tools via uv

### DIFF
--- a/src/uv-tool/devcontainer-feature.json
+++ b/src/uv-tool/devcontainer-feature.json
@@ -1,0 +1,42 @@
+{
+    "id": "uv-tool",
+    "version": "1.0.0",
+    "name": "Python tool (via uv)",
+    "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/uv-tool",
+    "description": "Installs a Python tool using uv.",
+    "options": {
+        "uv_version": {
+            "default": "latest",
+            "description": "The version of uv to install. Set to 'latest' to always get the latest version.",
+            "type": "string"
+        },
+        "package": {
+            "default": "",
+            "description": "The package to install commands from.",
+            "type": "string"
+        },
+        "from": {
+            "default": "",
+            "description": "Use the given package to provide the command. By default, the package name is assumed to match the command name.",
+            "type": "string"
+        },
+        "with": {
+            "default": "",
+            "description": "Space-separated list of additional packages to include as dependencies (does not install their executables). Supports version constraints, e.g., 'mkdocs-material mkdocs-minify-plugin>=0.7,<0.8'",
+            "type": "string"
+        },
+        "with-executables-from": {
+            "default": "",
+            "description": "Comma-separated list of packages to include as dependencies and install their executables, e.g., 'ansible-core,ansible-lint'",
+            "type": "string"
+        },
+        "python": {
+            "default": "",
+            "description": "Specify the Python version to use.",
+            "type": "string"
+        }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers-extra/features/uv"
+    ]
+}

--- a/src/uv-tool/install.sh
+++ b/src/uv-tool/install.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -e
+
+UV_VERSION="${UV_VERSION:-"latest"}"
+PACKAGE="${PACKAGE:-""}"
+FROM="${FROM:-""}"
+WITH="${WITH:-""}"
+WITH_EXECUTABLES_FROM="${WITH_EXECUTABLES_FROM:-""}"
+PYTHON="${PYTHON:-""}"
+
+USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
+
+# Validate required parameters
+if [ -z "${PACKAGE}" ]; then
+    echo "Error: PACKAGE option is required"
+    exit 1
+fi
+
+source ./library_scripts.sh
+
+# nanolayer is a cli utility which keeps container layers as small as possible
+# source code: https://github.com/devcontainers-extra/nanolayer
+# `ensure_nanolayer` is a bash function that will find any existing nanolayer installations,
+# and if missing - will download a temporary copy that automatically get deleted at the end
+# of the script
+ensure_nanolayer nanolayer_location "v0.5.6"
+
+$nanolayer_location \
+    install \
+    devcontainer-feature \
+    "ghcr.io/devcontainers-extra/features/uv:1" \
+    --option version="$UV_VERSION"
+
+# Determine the appropriate non-root user
+if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
+    USERNAME=""
+    possible_users=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
+    for current_user in "${possible_users[@]}"; do
+        if id -u "${current_user}" > /dev/null 2>&1; then
+            USERNAME=${current_user}
+            break
+        fi
+    done
+    if [ "${USERNAME}" = "" ]; then
+        USERNAME=root
+    fi
+elif [ "${USERNAME}" = "none" ] || ! id -u "${USERNAME}" > /dev/null 2>&1; then
+    USERNAME=root
+fi
+
+uv_args=("${PACKAGE}")
+
+[ -n "${FROM}" ] && uv_args+=(--from "${FROM}")
+[ -n "${WITH_EXECUTABLES_FROM}" ] && uv_args+=(--with-executables-from "${WITH_EXECUTABLES_FROM}")
+[ -n "${PYTHON}" ] && uv_args+=(--python "${PYTHON}")
+
+# Convert space-delimited WITH packages to multiple --with flags
+if [ -n "${WITH}" ]; then
+    read -ra with_array <<<"${WITH}"
+    for pkg in "${with_array[@]}"; do
+        [ -n "$pkg" ] && uv_args+=(--with "$pkg")
+    done
+fi
+
+if [ "${USERNAME}" != "root" ] && [ "${USERNAME}" != "" ]; then
+    echo "Installing ${PACKAGE} for user ${USERNAME}..."
+    # Export the uv_args array as a properly quoted string
+    uv_cmd="uv tool install $(printf '%q ' "${uv_args[@]}")"
+    sudo -u "${USERNAME}" bash -c "
+        export PATH=\"/home/${USERNAME}/.local/bin:\$PATH\"
+        ${uv_cmd}
+    "
+else
+    echo "Installing ${PACKAGE} for root..."
+    uv tool install "${uv_args[@]}"
+fi
+
+echo 'Done!'

--- a/src/uv-tool/library_scripts.sh
+++ b/src/uv-tool/library_scripts.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+
+clean_download() {
+    # The purpose of this function is to download a file with minimal impact on container layer size
+    # this means if no valid downloader is found (curl or wget) then we install a downloader (currently wget) in a
+    # temporary manner, and making sure to
+    # 1. uninstall the downloader at the return of the function
+    # 2. revert back any changes to the package installer database/cache (for example apt-get lists)
+    # The above steps will minimize the leftovers being created while installing the downloader
+    # Supported distros:
+    #  debian/ubuntu/alpine
+
+    url=$1
+    output_location=$2
+    tempdir=$(mktemp -d)
+    downloader_installed=""
+
+    function _apt_get_install() {
+        tempdir=$1
+
+        # copy current state of apt list - in order to revert back later (minimize contianer layer size)
+        cp -p -R /var/lib/apt/lists $tempdir
+        apt-get update -y
+        apt-get -y install --no-install-recommends wget ca-certificates
+    }
+
+    function _apt_get_cleanup() {
+        tempdir=$1
+
+        echo "removing wget"
+        apt-get -y purge wget --auto-remove
+
+        echo "revert back apt lists"
+        rm -rf /var/lib/apt/lists/*
+        rm -r /var/lib/apt/lists && mv $tempdir/lists /var/lib/apt/lists
+    }
+
+    function _apk_install() {
+        tempdir=$1
+        # copy current state of apk cache - in order to revert back later (minimize contianer layer size)
+        cp -p -R /var/cache/apk $tempdir
+
+        apk add --no-cache wget
+    }
+
+    function _apk_cleanup() {
+        tempdir=$1
+
+        echo "removing wget"
+        apk del wget
+    }
+    # try to use either wget or curl if one of them already installer
+    if type curl >/dev/null 2>&1; then
+        downloader=curl
+    elif type wget >/dev/null 2>&1; then
+        downloader=wget
+    else
+        downloader=""
+    fi
+
+    # in case none of them is installed, install wget temporarly
+    if [ -z $downloader ]; then
+        if [ -x "/usr/bin/apt-get" ]; then
+            _apt_get_install $tempdir
+        elif [ -x "/sbin/apk" ]; then
+            _apk_install $tempdir
+        else
+            echo "distro not supported"
+            exit 1
+        fi
+        downloader="wget"
+        downloader_installed="true"
+    fi
+
+    if [ $downloader = "wget" ]; then
+        wget -q $url -O $output_location
+    else
+        curl -sfL $url -o $output_location
+    fi
+
+    # NOTE: the cleanup procedure was not implemented using `trap X RETURN` only because
+    # alpine lack bash, and RETURN is not a valid signal under sh shell
+    if ! [ -z $downloader_installed ]; then
+        if [ -x "/usr/bin/apt-get" ]; then
+            _apt_get_cleanup $tempdir
+        elif [ -x "/sbin/apk" ]; then
+            _apk_cleanup $tempdir
+        else
+            echo "distro not supported"
+            exit 1
+        fi
+    fi
+
+}
+
+ensure_nanolayer() {
+    # Ensure existance of the nanolayer cli program
+    local variable_name=$1
+
+    local required_version=$2
+    # normalize version
+    if ! [[ $required_version == v* ]]; then
+        required_version=v$required_version
+    fi
+
+    local nanolayer_location=""
+
+    # If possible - try to use an already installed nanolayer
+    if [[ -z "${NANOLAYER_FORCE_CLI_INSTALLATION}" ]]; then
+        if [[ -z "${NANOLAYER_CLI_LOCATION}" ]]; then
+            if type nanolayer >/dev/null 2>&1; then
+                echo "Found a pre-existing nanolayer in PATH"
+                nanolayer_location=nanolayer
+            fi
+        elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ]; then
+            nanolayer_location=${NANOLAYER_CLI_LOCATION}
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
+        fi
+
+        # make sure its of the required version
+        if ! [[ -z "${nanolayer_location}" ]]; then
+            local current_version
+            current_version=$($nanolayer_location --version)
+            if ! [[ $current_version == v* ]]; then
+                current_version=v$current_version
+            fi
+
+            if ! [ $current_version == $required_version ]; then
+                echo "skipping usage of pre-existing nanolayer. (required version $required_version does not match existing version $current_version)"
+                nanolayer_location=""
+            fi
+        fi
+
+    fi
+
+    # If not previuse installation found, download it temporarly and delete at the end of the script
+    if [[ -z "${nanolayer_location}" ]]; then
+
+        if [ "$(uname -sm)" == "Linux x86_64" ] || [ "$(uname -sm)" == "Linux aarch64" ]; then
+            tmp_dir=$(mktemp -d -t nanolayer-XXXXXXXXXX)
+
+            clean_up() {
+                ARG=$?
+                rm -rf $tmp_dir
+                exit $ARG
+            }
+            trap clean_up EXIT
+
+            if [ -x "/sbin/apk" ]; then
+                clib_type=musl
+            else
+                clib_type=gnu
+            fi
+
+            tar_filename=nanolayer-"$(uname -m)"-unknown-linux-$clib_type.tgz
+
+            # clean download will minimize leftover in case a downloaderlike wget or curl need to be installed
+            clean_download https://github.com/devcontainers-extra/nanolayer/releases/download/$required_version/$tar_filename $tmp_dir/$tar_filename
+
+            tar xfzv $tmp_dir/$tar_filename -C "$tmp_dir"
+            chmod a+x $tmp_dir/nanolayer
+            nanolayer_location=$tmp_dir/nanolayer
+
+        else
+            echo "No binaries compiled for non-x86-linux architectures yet: $(uname -m)"
+            exit 1
+        fi
+    fi
+
+    # Expose outside the resolved location
+    declare -g ${variable_name}=$nanolayer_location
+
+}

--- a/test/uv-tool/install_tool_using_from.sh
+++ b/test/uv-tool/install_tool_using_from.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "httpie is installed" http --version
+
+reportResults

--- a/test/uv-tool/install_tool_using_multiple_with.sh
+++ b/test/uv-tool/install_tool_using_multiple_with.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "mkdocs is installed" mkdocs --version
+check "mkdocs-material theme is available" sh -c "cd $(uv tool dir)/mkdocs && uv pip list | grep mkdocs-material"
+check "mkdocs-minify-plugin is available" sh -c "cd $(uv tool dir)/mkdocs && uv pip list | grep mkdocs-minify-plugin"
+
+reportResults

--- a/test/uv-tool/install_tool_using_uv_version.sh
+++ b/test/uv-tool/install_tool_using_uv_version.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "uv tool version" sh -c "uv --version | grep 0.9.6"
+check "httpie is installed" http --version
+
+reportResults

--- a/test/uv-tool/install_tool_using_with.sh
+++ b/test/uv-tool/install_tool_using_with.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "mkdocs-material theme is available" sh -c "cd $(uv tool dir)/mkdocs && uv pip list | grep mkdocs-material"
+
+reportResults

--- a/test/uv-tool/install_tool_using_with_executables_from_and_python.sh
+++ b/test/uv-tool/install_tool_using_with_executables_from_and_python.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "ansible is installed" ansible --version
+check "ansible-core executables are available" ansible-playbook --version
+check "ansible-lint is available" ansible-lint --version
+
+check "ansible uses Python 3.13" sh -c "ansible --version | grep 'python version = 3.13'"
+
+reportResults

--- a/test/uv-tool/scenarios.json
+++ b/test/uv-tool/scenarios.json
@@ -1,0 +1,48 @@
+{
+    "install_tool_using_uv_version": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "uv-tool": {
+                "uv_version": "0.9.6",
+                "package": "httpie"
+            }
+        }
+    },
+    "install_tool_using_from": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "uv-tool": {
+                "package": "httpie",
+                "from": "git+https://github.com/httpie/cli"
+            }
+        }
+    },
+    "install_tool_using_with": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "uv-tool": {
+                "package": "mkdocs",
+                "with": "mkdocs-material"
+            }
+        }
+    },
+    "install_tool_using_multiple_with": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "uv-tool": {
+                "package": "mkdocs",
+                "with": "mkdocs-material mkdocs-minify-plugin"
+            }
+        }
+    },
+    "install_tool_using_with_executables_from_and_python": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "uv-tool": {
+                "package": "ansible",
+                "with-executables-from": "ansible-core,ansible-lint",
+                "python": "3.13"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Supports options: package, from, with, with-executables-from, python, and uv_version to provide full uv tool install functionality.

Closes #162