### PR TITLE
chore: Caddy install.sh dependency updates

### DIFF
--- a/src/caddy/devcontainer-feature.json
+++ b/src/caddy/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "caddy",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "name": "Caddy (via Github Releases)",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/caddy",
     "description": "Caddy is a powerful, enterprise-ready, open source web server with automatic HTTPS.",

--- a/src/caddy/install.sh
+++ b/src/caddy/install.sh
@@ -8,13 +8,13 @@ set -e
 # `ensure_nanolayer` is a bash function that will find any existing nanolayer installations,
 # and if missing - will download a temporary copy that automatically get deleted at the end
 # of the script
-ensure_nanolayer nanolayer_location "v0.5.4"
+ensure_nanolayer nanolayer_location "v0.5.6"
 
 
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers/features/go:1.1.3" \
+    "ghcr.io/devcontainers/features/go:1.3.4" \
     --option version="$GOLANGVERSION"
 
 
@@ -22,7 +22,7 @@ $nanolayer_location \
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-extra/features/gh-release:1.0.25" \
+    "ghcr.io/devcontainers-extra/features/gh-release:1.0.26" \
     --option repo='caddyserver/caddy' --option binaryNames='caddy' --option version="$VERSION"
 
 


### PR DESCRIPTION
Only the Go version was strictly necessary due to https://github.com/golangci/golangci-lint/issues/6555, but bumping the others while here.

The official Go feature was updated recently to address the change: https://github.com/devcontainers/features/issues/1635.