### PR TITLE
Feature/add tflint

### DIFF
--- a/src/tflint/README.md
+++ b/src/tflint/README.md
@@ -1,0 +1,24 @@
+
+# TFLint (via Github Releases) (tflint)
+
+TFLint is a framework and each feature is provided by plugins, the key features are as follows:
+
+- Find possible errors (like invalid instance types) for Major Cloud providers (AWS/Azure/GCP).
+- Warn about deprecated syntax, unused declarations.
+- Enforce best practices, naming conventions.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/devcontainers-extra/features/tflint:1": {}
+}
+```
+
+## Options
+
+| Options Id | Description                    | Type   | Default Value |
+|------------|--------------------------------|--------|---------------|
+| version    | Select the version to install. | string | latest        |
+
+---

--- a/src/tflint/devcontainer-feature.json
+++ b/src/tflint/devcontainer-feature.json
@@ -1,0 +1,20 @@
+{
+    "id": "tflint",
+    "version": "1.0.0",
+    "name": "tflint (via Github Releases)",
+    "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/tflint",
+    "description": "A Pluggable Terraform Linter",
+    "options": {
+        "version": {
+            "default": "latest",
+            "description": "Select the version to install.",
+            "proposals": [
+                "latest"
+            ],
+            "type": "string"
+        }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers-extra/features/gh-release"
+    ]
+}

--- a/src/tflint/install.sh
+++ b/src/tflint/install.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+source ./library_scripts.sh
+
+# nanolayer is a cli utility which keeps container layers as small as possible
+# source code: https://github.com/devcontainers-extra/nanolayer
+# `ensure_nanolayer` is a bash function that will find any existing nanolayer installations,
+# and if missing - will download a temporary copy that automatically get deleted at the end
+# of the script
+ensure_nanolayer nanolayer_location "v0.5.6"
+
+# Example nanolayer installation via devcontainer-feature
+$nanolayer_location \
+    install \
+    devcontainer-feature \
+    "ghcr.io/devcontainers-extra/features/gh-release:1" \
+    --option repo='terraform-linters/tflint' --option binaryNames='tflint' --option version="$VERSION"
+
+echo 'Done!'

--- a/src/tflint/library_scripts.sh
+++ b/src/tflint/library_scripts.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+
+clean_download() {
+    # The purpose of this function is to download a file with minimal impact on container layer size
+    # this means if no valid downloader is found (curl or wget) then we install a downloader (currently wget) in a
+    # temporary manner, and making sure to
+    # 1. uninstall the downloader at the return of the function
+    # 2. revert back any changes to the package installer database/cache (for example apt-get lists)
+    # The above steps will minimize the leftovers being created while installing the downloader
+    # Supported distros:
+    #  debian/ubuntu/alpine
+
+    url=$1
+    output_location=$2
+    tempdir=$(mktemp -d)
+    downloader_installed=""
+
+    function _apt_get_install() {
+        tempdir=$1
+
+        # copy current state of apt list - in order to revert back later (minimize contianer layer size)
+        cp -p -R /var/lib/apt/lists $tempdir
+        apt-get update -y
+        apt-get -y install --no-install-recommends wget ca-certificates
+    }
+
+    function _apt_get_cleanup() {
+        tempdir=$1
+
+        echo "removing wget"
+        apt-get -y purge wget --auto-remove
+
+        echo "revert back apt lists"
+        rm -rf /var/lib/apt/lists/*
+        rm -r /var/lib/apt/lists && mv $tempdir/lists /var/lib/apt/lists
+    }
+
+    function _apk_install() {
+        tempdir=$1
+        # copy current state of apk cache - in order to revert back later (minimize contianer layer size)
+        cp -p -R /var/cache/apk $tempdir
+
+        apk add --no-cache wget
+    }
+
+    function _apk_cleanup() {
+        tempdir=$1
+
+        echo "removing wget"
+        apk del wget
+    }
+    # try to use either wget or curl if one of them already installer
+    if type curl >/dev/null 2>&1; then
+        downloader=curl
+    elif type wget >/dev/null 2>&1; then
+        downloader=wget
+    else
+        downloader=""
+    fi
+
+    # in case none of them is installed, install wget temporarly
+    if [ -z $downloader ]; then
+        if [ -x "/usr/bin/apt-get" ]; then
+            _apt_get_install $tempdir
+        elif [ -x "/sbin/apk" ]; then
+            _apk_install $tempdir
+        else
+            echo "distro not supported"
+            exit 1
+        fi
+        downloader="wget"
+        downloader_installed="true"
+    fi
+
+    if [ $downloader = "wget" ]; then
+        wget -q $url -O $output_location
+    else
+        curl -sfL $url -o $output_location
+    fi
+
+    # NOTE: the cleanup procedure was not implemented using `trap X RETURN` only because
+    # alpine lack bash, and RETURN is not a valid signal under sh shell
+    if ! [ -z $downloader_installed ]; then
+        if [ -x "/usr/bin/apt-get" ]; then
+            _apt_get_cleanup $tempdir
+        elif [ -x "/sbin/apk" ]; then
+            _apk_cleanup $tempdir
+        else
+            echo "distro not supported"
+            exit 1
+        fi
+    fi
+
+}
+
+ensure_nanolayer() {
+    # Ensure existance of the nanolayer cli program
+    local variable_name=$1
+
+    local required_version=$2
+    # normalize version
+    if ! [[ $required_version == v* ]]; then
+        required_version=v$required_version
+    fi
+
+    local nanolayer_location=""
+
+    # If possible - try to use an already installed nanolayer
+    if [[ -z "${NANOLAYER_FORCE_CLI_INSTALLATION}" ]]; then
+        if [[ -z "${NANOLAYER_CLI_LOCATION}" ]]; then
+            if type nanolayer >/dev/null 2>&1; then
+                echo "Found a pre-existing nanolayer in PATH"
+                nanolayer_location=nanolayer
+            fi
+        elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ]; then
+            nanolayer_location=${NANOLAYER_CLI_LOCATION}
+            echo "Found a pre-existing nanolayer which were given in env variable: $nanolayer_location"
+        fi
+
+        # make sure its of the required version
+        if ! [[ -z "${nanolayer_location}" ]]; then
+            local current_version
+            current_version=$($nanolayer_location --version)
+            if ! [[ $current_version == v* ]]; then
+                current_version=v$current_version
+            fi
+
+            if ! [ $current_version == $required_version ]; then
+                echo "skipping usage of pre-existing nanolayer. (required version $required_version does not match existing version $current_version)"
+                nanolayer_location=""
+            fi
+        fi
+
+    fi
+
+    # If not previuse installation found, download it temporarly and delete at the end of the script
+    if [[ -z "${nanolayer_location}" ]]; then
+
+        if [ "$(uname -sm)" == "Linux x86_64" ] || [ "$(uname -sm)" == "Linux aarch64" ]; then
+            tmp_dir=$(mktemp -d -t nanolayer-XXXXXXXXXX)
+
+            clean_up() {
+                ARG=$?
+                rm -rf $tmp_dir
+                exit $ARG
+            }
+            trap clean_up EXIT
+
+            if [ -x "/sbin/apk" ]; then
+                clib_type=musl
+            else
+                clib_type=gnu
+            fi
+
+            tar_filename=nanolayer-"$(uname -m)"-unknown-linux-$clib_type.tgz
+
+            # clean download will minimize leftover in case a downloaderlike wget or curl need to be installed
+            clean_download https://github.com/devcontainers-extra/nanolayer/releases/download/$required_version/$tar_filename $tmp_dir/$tar_filename
+
+            tar xfzv $tmp_dir/$tar_filename -C "$tmp_dir"
+            chmod a+x $tmp_dir/nanolayer
+            nanolayer_location=$tmp_dir/nanolayer
+
+        else
+            echo "No binaries compiled for non-x86-linux architectures yet: $(uname -m)"
+            exit 1
+        fi
+    fi
+
+    # Expose outside the resolved location
+    declare -g ${variable_name}=$nanolayer_location
+
+}

--- a/test/tflint/scenarios.json
+++ b/test/tflint/scenarios.json
@@ -9,7 +9,7 @@
         "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "tflint": {
-                "version": "0.62.1"
+                "version": "0.62.0"
             }
         }
     }

--- a/test/tflint/scenarios.json
+++ b/test/tflint/scenarios.json
@@ -1,0 +1,16 @@
+{
+    "test_default": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "tflint": {}
+        }
+    },
+    "test_specific_version": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "tflint": {
+                "version": "0.62.1"
+            }
+        }
+    }
+}

--- a/test/tflint/test.sh
+++ b/test/tflint/test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "something is installed" tflint --version
+
+reportResults

--- a/test/tflint/test_default.sh
+++ b/test/tflint/test_default.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "tflint is installed" tflint --version
+
+reportResults

--- a/test/tflint/test_specific_version.sh
+++ b/test/tflint/test_specific_version.sh
@@ -4,6 +4,6 @@ set -e
 
 source dev-container-features-test-lib
 
-check "tflint version is equal to 0.62.1" sh -c "tflint --version | grep '0.62.1'"
+check "tflint version is equal to 0.62.0" sh -c "tflint --version | grep '0.62.0'"
 
 reportResults

--- a/test/tflint/test_specific_version.sh
+++ b/test/tflint/test_specific_version.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "tflint version is equal to 0.62.1" sh -c "tflint --version | grep '0.62.1'"
+
+reportResults


### PR DESCRIPTION
Added a new feature to install tflint.
The existing feature for Terraform already includes tflint by default. However, when OpenTofu-counterpart (also part of this repo) does not. By creating this new feature, OpenTofu-users can also use tflint for the files