### PR TITLE
Update download URL for claude-code releases

### DIFF
--- a/src/claude-code/bootstrap.sh
+++ b/src/claude-code/bootstrap.sh
@@ -11,7 +11,7 @@ if [[ -n "$TARGET" ]] && [[ ! "$TARGET" =~ ^(stable|latest|[0-9]+\.[0-9]+\.[0-9]
     exit 1
 fi
 
-GCS_BUCKET="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
+DOWNLOAD_BASE_URL="https://downloads.claude.ai/claude-code-releases"
 DOWNLOAD_DIR="$HOME/.claude/downloads"
 
 # Check for required dependencies
@@ -105,10 +105,10 @@ fi
 mkdir -p "$DOWNLOAD_DIR"
 
 # Always download latest version (which has the most up-to-date installer)
-version=$(download_file "$GCS_BUCKET/latest")
+version=$(download_file "$DOWNLOAD_BASE_URL/latest")
 
 # Download manifest and extract checksum
-manifest_json=$(download_file "$GCS_BUCKET/$version/manifest.json")
+manifest_json=$(download_file "$DOWNLOAD_BASE_URL/$version/manifest.json")
 
 # Use jq if available, otherwise fall back to pure bash parsing
 if [ "$HAS_JQ" = true ]; then
@@ -125,7 +125,7 @@ fi
 
 # Download and verify
 binary_path="$DOWNLOAD_DIR/claude-$version-$platform"
-if ! download_file "$GCS_BUCKET/$version/$platform/claude" "$binary_path"; then
+if ! download_file "$DOWNLOAD_BASE_URL/$version/$platform/claude" "$binary_path"; then
     echo "Download failed" >&2
     rm -f "$binary_path"
     exit 1

--- a/src/claude-code/devcontainer-feature.json
+++ b/src/claude-code/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "claude-code",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "name": "claude-code",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/claude-code",
     "description": "Claude Code is an agentic coding tool that lives in your terminal",


### PR DESCRIPTION
Follow official install script and use official urls from https://downloads.claude.ai/claude-code-releases/bootstrap.sh