### PR TITLE
[apt-packages] Fix tests

### DIFF
--- a/test/apt-packages/scenarios.json
+++ b/test/apt-packages/scenarios.json
@@ -1,6 +1,6 @@
 {
     "test_neovim_ubuntu": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu24.04",
         "features": {
             "apt-packages": {
                 "packages": "neovim",


### PR DESCRIPTION
Set the Ubuntu image version to 24.04 since the neovim package is not yet available for 26.04 in de PPA