### PR TITLE
Fix claude-code installing files owned by root

### DIFF
--- a/src/claude-code/devcontainer-feature.json
+++ b/src/claude-code/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "claude-code",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "name": "claude-code",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/claude-code",
     "description": "Claude Code is an agentic coding tool that lives in your terminal",

--- a/src/claude-code/install.sh
+++ b/src/claude-code/install.sh
@@ -5,10 +5,18 @@ set -e
 # Install via Anthropic's recommended method
 # Script downloaded from them:
 # https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/bootstrap.sh
-bash "$(dirname "$0")/bootstrap.sh" "$VERSION"
+
+# Resolve the absolute path before su changes the working directory
+BOOTSTRAP_SCRIPT="$(pwd)/bootstrap.sh"
+
+# Run as the devcontainer user so that ~/.claude/, ~/.local/bin/claude, and
+# ~/.local/share/claude/ are owned by the right user, not root.
+su - "$_REMOTE_USER" <<EOF
+bash "$BOOTSTRAP_SCRIPT" "$VERSION"
+EOF
 
 # Copy the binary to /usr/local/bin for global access
-# It's installed in /root/.local/bin/claude and there's no option to override the install location
-cp "$HOME/.local/bin/claude" /usr/local/bin/claude
+# It's installed in ~/.local/bin/claude and there's no option to override the install location
+cp "$_REMOTE_USER_HOME/.local/bin/claude" /usr/local/bin/claude
 
 echo 'Done!'

--- a/test/claude-code/test_debian.sh
+++ b/test/claude-code/test_debian.sh
@@ -5,5 +5,7 @@ set -e
 source dev-container-features-test-lib
 
 check "claude is installed" claude --version
+check "~/.claude is owned by the current user" test "$(stat -c %u "$HOME/.claude")" = "$(id -u)"
+check "~/.local/share/claude is owned by the current user" test "$(stat -c %u "$HOME/.local/share/claude")" = "$(id -u)"
 
 reportResults


### PR DESCRIPTION
`bootstrap.sh` was running as root, so `~/.claude/`, `~/.local/bin/claude`, and `~/.local/share/claude/` all ended up under `/root/` owned by root. The devcontainer user had no access to config or shell integration.

Use the devcontainer spec variables `_REMOTE_USER` and `_REMOTE_USER_HOME` to run the install as the devcontainer user, following the pattern used by `asdf-package`, `homebrew-package`, and other features in this repo.