### PR TITLE
fix: install fails with unset _REMOTE_USER_HOME

### DIFF
--- a/src/claude-code/devcontainer-feature.json
+++ b/src/claude-code/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "claude-code",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "name": "claude-code",
     "documentationURL": "http://github.com/devcontainers-extra/features/tree/main/src/claude-code",
     "description": "Claude Code is an agentic coding tool that lives in your terminal",

--- a/src/claude-code/install.sh
+++ b/src/claude-code/install.sh
@@ -2,6 +2,13 @@
 
 set -e
 
+# Make sure that variable _REMOTE_USER_HOME is properly set
+if [ -z "$_REMOTE_USER_HOME" ]; then
+    # shellcheck disable=2016 # this is intentional as the expansion should happen in the context of the new session
+    _REMOTE_USER_HOME="$(su - "$_REMOTE_USER" -c 'echo "$HOME"')"
+    export _REMOTE_USER_HOME
+fi
+
 # Install via Anthropic's recommended method
 # Script downloaded from them:
 # https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/bootstrap.sh


### PR DESCRIPTION
As mentioned by @ZhiliangWu in #229, the installation currently fails if the `_REMOTE_USER_HOME` variable was not set properly by devcontainer CLI.

I did **not** add a test, as I didn't find a way to unset the variable before the installation starts.